### PR TITLE
i18n.ts to fix Prev -> Previous instead of Preview

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -62,7 +62,7 @@ const resources = {
       ResultPath: 'Result Path',
       ConfirmToDelete: 'Confirm To Delete',
       OutOfTargetAnnotation: 'Out-Of-Target',
-      CopyThePreview: 'Copy The Preview',
+      CopyThePreview: 'Copy The Previous Annotation',
       ShowOrder: 'Show Order',
       Detection: 'Detection',
       Classification: 'Classification',


### PR DESCRIPTION
Problem:
- There is a translation issue where Prev is supposed to mean `previous` instead of `preview`. 

Solution: 
- This commit tries to fix this by changing the correct


Reference:
- Settings when creating project<br/> ![image](https://user-images.githubusercontent.com/1798412/235406215-cf9af3c6-54fe-4940-9ebb-d37b1e068a14.png)
- "Copy Prev" butting during labeling process <br/> I can see the reason of mistranslation here <br/>![image](https://user-images.githubusercontent.com/1798412/235406167-1bd69bba-e61d-48a3-8a6c-438f07ea86c4.png)



